### PR TITLE
Use specific DecimalTableViewCell for decimal cell…

### DIFF
--- a/Formulary.xcodeproj/project.pbxproj
+++ b/Formulary.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		24D15F3A1B766A9E00768880 /* DecimalInputTextFieldDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D15F391B766A9E00768880 /* DecimalInputTextFieldDelegate.swift */; };
 		E74C7DC41A709D1E00237881 /* Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74C7DC31A709D1E00237881 /* Validation.swift */; };
 		E74C7DC61A71C8F900237881 /* OptionSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74C7DC51A71C8F900237881 /* OptionSection.swift */; };
 		E74FCA0A1A70314000C8BB8A /* KeyboardNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74FCA091A70314000C8BB8A /* KeyboardNotification.swift */; };
@@ -68,6 +69,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		24D15F391B766A9E00768880 /* DecimalInputTextFieldDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecimalInputTextFieldDelegate.swift; sourceTree = "<group>"; };
 		E74C7DC31A709D1E00237881 /* Validation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Validation.swift; sourceTree = "<group>"; };
 		E74C7DC51A71C8F900237881 /* OptionSection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionSection.swift; sourceTree = "<group>"; };
 		E74FCA091A70314000C8BB8A /* KeyboardNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardNotification.swift; sourceTree = "<group>"; };
@@ -246,6 +248,7 @@
 				E77EEE771A6B137D00AD4289 /* NamedTextField.swift */,
 				E74FCA091A70314000C8BB8A /* KeyboardNotification.swift */,
 				E74C7DC31A709D1E00237881 /* Validation.swift */,
+				24D15F391B766A9E00768880 /* DecimalInputTextFieldDelegate.swift */,
 			);
 			path = Input;
 			sourceTree = "<group>";
@@ -430,6 +433,7 @@
 				E7F1A95E1A69A34700FD8294 /* Form.swift in Sources */,
 				E74C7DC41A709D1E00237881 /* Validation.swift in Sources */,
 				E74FCA0A1A70314000C8BB8A /* KeyboardNotification.swift in Sources */,
+				24D15F3A1B766A9E00768880 /* DecimalInputTextFieldDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Formulary/Forms/Cell.swift
+++ b/Formulary/Forms/Cell.swift
@@ -32,69 +32,15 @@ extension UITableView {
         
         self.registerClass(FormTableViewCell.self, forCellReuseIdentifier: FormRowType.Text.rawValue)
         self.registerClass(FormTableViewCell.self, forCellReuseIdentifier: FormRowType.Number.rawValue)
-        self.registerClass(FormTableViewCell.self, forCellReuseIdentifier: FormRowType.Decimal.rawValue)
+        self.registerClass(DecimalTableViewCell.self, forCellReuseIdentifier: FormRowType.Decimal.rawValue)
         self.registerClass(FormTableViewCell.self, forCellReuseIdentifier: FormRowType.Email.rawValue)
         self.registerClass(FormTableViewCell.self, forCellReuseIdentifier: FormRowType.Twitter.rawValue)
         self.registerClass(FormTableViewCell.self, forCellReuseIdentifier: FormRowType.URL.rawValue)
     }
 }
 
-func configureCell(cell: FormTableViewCell, inout row: FormRow) {
-    
-    cell.action = nil
-    cell.formRow = row
-    
-    switch row.type {
-    case .Plain:
-        cell.textLabel?.text = row.name
-        break
-    case .Switch:
-        cell.textLabel?.text = row.name
-        let s = UISwitch()
-        cell.accessoryView = s
-        ActionTarget(control: s, action: { _ in
-            row.value = s.on
-        })
-        
-        if let enabled = row.value as? Bool {
-            s.on = enabled
-        }
-    case .Toggle:
-        cell.textLabel?.text = row.name
-        cell.accessoryType = ((row.value as? Bool) ?? false) ? UITableViewCellAccessoryType.Checkmark : .None
-        
-        cell.action = { x in
-            cell.accessoryType = ((row.value as? Bool) ?? false) ? UITableViewCellAccessoryType.Checkmark : .None
-        }
-        
-    case .Button:
-        let button = UIButton(frame: cell.bounds)
-        
-        button.setTitle(row.name, forState: .Normal)
-        button.setTitleColor(cell.tintColor, forState: .Normal)
-
-        button.setTranslatesAutoresizingMaskIntoConstraints(false)
-        cell.contentView.addSubview(button)
-        cell.contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|-[button]-|", options: nil, metrics: nil, views: ["button":button]))
-        cell.contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|-[button]-|", options: nil, metrics: nil, views: ["button":button]))
-        
-        var emptyAction :Action = { _ in }
-        
-        ActionTarget(control: button, controlEvents: UIControlEvents.TouchUpInside, action: row.action ?? emptyAction)
-    case .Text:
-        configureTextCell(cell, &row).keyboardType = .Default
-    case .Number:
-        configureTextCell(cell, &row).keyboardType = .NumberPad
-    case .Decimal:
-        configureTextCell(cell, &row).keyboardType = .DecimalPad
-    case .Email:
-        configureTextCell(cell, &row).keyboardType = .EmailAddress
-    case .Twitter:
-        configureTextCell(cell, &row).keyboardType = .Twitter
-    case .URL:
-        configureTextCell(cell, &row).keyboardType = .URL
-    }
-    cell.selectionStyle = .None
+protocol FormTableViewCellType {
+    func configureCell(inout row: FormRow)
 }
 
 func configureTextCell(cell: FormTableViewCell, inout row: FormRow) -> UITextField {
@@ -124,11 +70,78 @@ func configureTextCell(cell: FormTableViewCell, inout row: FormRow) -> UITextFie
     return textField!
 }
 
-class FormTableViewCell: UITableViewCell {
+class FormTableViewCell: UITableViewCell, FormTableViewCellType {
     var configured: Bool = false
     var formRow: FormRow?
     var action :Action?
     var textField :NamedTextField?
+    
+    func configureCell(inout row: FormRow) {
+        self.action = nil
+        self.formRow = row
+        
+        switch row.type {
+        case .Plain:
+            self.textLabel?.text = row.name
+            break
+        case .Switch:
+            self.textLabel?.text = row.name
+            let s = UISwitch()
+            self.accessoryView = s
+            ActionTarget(control: s, action: { _ in
+                row.value = s.on
+            })
+            
+            if let enabled = row.value as? Bool {
+                s.on = enabled
+            }
+        case .Toggle:
+            self.textLabel?.text = row.name
+            self.accessoryType = ((row.value as? Bool) ?? false) ? UITableViewCellAccessoryType.Checkmark : .None
+            
+            self.action = { x in
+                self.accessoryType = ((row.value as? Bool) ?? false) ? UITableViewCellAccessoryType.Checkmark : .None
+            }
+            
+        case .Button:
+            let button = UIButton(frame: self.bounds)
+            
+            button.setTitle(row.name, forState: .Normal)
+            button.setTitleColor(self.tintColor, forState: .Normal)
+            
+            button.setTranslatesAutoresizingMaskIntoConstraints(false)
+            self.contentView.addSubview(button)
+            self.contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("H:|-[button]-|", options: nil, metrics: nil, views: ["button":button]))
+            self.contentView.addConstraints(NSLayoutConstraint.constraintsWithVisualFormat("V:|-[button]-|", options: nil, metrics: nil, views: ["button":button]))
+            
+            var emptyAction :Action = { _ in }
+            
+            ActionTarget(control: button, controlEvents: UIControlEvents.TouchUpInside, action: row.action ?? emptyAction)
+        case .Text:
+            configureTextCell(self, &row).keyboardType = .Default
+        case .Number:
+            configureTextCell(self, &row).keyboardType = .NumberPad
+        case .Decimal:
+            configureTextCell(self, &row).keyboardType = .DecimalPad
+        case .Email:
+            configureTextCell(self, &row).keyboardType = .EmailAddress
+        case .Twitter:
+            configureTextCell(self, &row).keyboardType = .Twitter
+        case .URL:
+            configureTextCell(self, &row).keyboardType = .URL
+        }
+        self.selectionStyle = .None
+    }
+}
+
+class DecimalTableViewCell: FormTableViewCell {
+    let inputDelegate = DecimalInputTextFieldDelegate()
+
+    override func configureCell(inout row: FormRow) {
+        super.configureCell(&row)
+        
+        self.textField?.delegate = inputDelegate
+    }
 }
 
 let ActionTargetControlKey :UnsafePointer<Void> = UnsafePointer<Void>()

--- a/Formulary/Forms/FormDataSource.swift
+++ b/Formulary/Forms/FormDataSource.swift
@@ -29,7 +29,7 @@ class FormDataSource: NSObject, UITableViewDataSource {
     func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
         var row = rowForIndexPath(indexPath, form)
         let cell = tableView.dequeueReusableCellWithIdentifier(identifier(row)) as! FormTableViewCell
-        configureCell(cell, &row)
+        cell.configureCell(&row)
         return cell
     }
     

--- a/Formulary/Input/DecimalInputTextFieldDelegate.swift
+++ b/Formulary/Input/DecimalInputTextFieldDelegate.swift
@@ -1,0 +1,23 @@
+//
+//  DecimalInputTextFieldDelegate.swift
+//  Formulary
+//
+//  Created by Timm Preetz on 8.8.2015.
+//  Copyright (c) 2015 Fabian Canas. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class DecimalInputTextFieldDelegate : NSObject, UITextFieldDelegate {
+    func textField(textField: UITextField, shouldChangeCharactersInRange range: NSRange, replacementString string: String) -> Bool {
+        
+        let textWithNewCharacters: String = (textField.text as NSString).stringByReplacingCharactersInRange(range, withString: string)
+
+        if textWithNewCharacters == "" {
+            return true
+        }
+        
+        return NSNumberFormatter().numberFromString(textWithNewCharacters)?.doubleValue != nil
+    }
+}


### PR DESCRIPTION
that does not allow non-decimal input characters

Would fix #4 

As you can see this currently feels a little tagged on.

This is why I would suggest to build specific classes for each row type (most probably based on the same subclass) and then get rid of the massive switch statement configuring this uber-flexible cell.
